### PR TITLE
Extending CronTask model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-/nbproject

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/nbproject

--- a/src/migrations/m201014_143840_add_name_and_description_to_cron_task.php
+++ b/src/migrations/m201014_143840_add_name_and_description_to_cron_task.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace gaxz\crontab\migrations;
+
+use yii\db\Migration;
+
+/**
+ * Class m201014_143840_add_name_and_description_to_cron_task
+ */
+class m201014_143840_add_name_and_description_to_cron_task extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->addColumn('{{%cron_task}}', 'name', $this->string(50)->after('id'));
+        $this->addColumn('{{%cron_task}}', 'description', $this->string()->after('name'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropColumn('{{%cron_task}}', 'description');
+        $this->dropColumn('{{%cron_task}}', 'name');
+    }
+
+    /*
+    // Use up()/down() to run migration code without a transaction.
+    public function up()
+    {
+
+    }
+
+    public function down()
+    {
+        echo "m201014_143840_add_name_and_description_to_cron_task cannot be reverted.\n";
+
+        return false;
+    }
+    */
+}

--- a/src/models/CronTask.php
+++ b/src/models/CronTask.php
@@ -127,4 +127,13 @@ class CronTask extends ActiveRecord
     {
         return "{$this->schedule} {$phpBin} {$yiiBootstrap} {$route} {$this->id} {$outputSetting}";
     }
+
+    public function getPrettyName()
+    {
+        if (empty($this->name)) {
+            return "ID: {$this->id} ({$this->route})";
+        }
+
+        return "ID: {$this->id} - {$this->name}";
+    }
 }

--- a/src/models/CronTask.php
+++ b/src/models/CronTask.php
@@ -38,10 +38,12 @@ class CronTask extends ActiveRecord
     public function rules()
     {
         return [
+            [['name'], 'string', 'max' => 50],
+            [['name', 'description'], 'default', 'value' => null],
             [['created_at', 'updated_at'], 'safe'],
             [['is_enabled'], 'integer'],
             [['params'], 'validateJson'],
-            [['schedule', 'route'], 'string', 'max' => 255],
+            [['schedule', 'route', 'description'], 'string', 'max' => 255],
             [['schedule'], 'match', 'pattern' => self::SCHEDULE_REGEX],
             [['schedule', 'route'], 'required'],
         ];
@@ -71,6 +73,8 @@ class CronTask extends ActiveRecord
     {
         return [
             'id' => 'ID',
+            'name' => 'Name',
+            'description' => 'Description',
             'created_at' => 'Created At',
             'updated_at' => 'Updated At',
             'schedule' => 'Schedule',

--- a/src/models/CronTaskSearch.php
+++ b/src/models/CronTaskSearch.php
@@ -18,7 +18,7 @@ class CronTaskSearch extends CronTask
     {
         return [
             [['id', 'is_enabled'], 'integer'],
-            [['created_at', 'updated_at', 'schedule', 'route'], 'safe'],
+            [['created_at', 'updated_at', 'schedule', 'route', 'name', 'description'], 'safe'],
         ];
     }
 
@@ -65,7 +65,9 @@ class CronTaskSearch extends CronTask
         ]);
 
         $query->andFilterWhere(['like', 'schedule', $this->schedule])
-            ->andFilterWhere(['like', 'route', $this->route]);
+            ->andFilterWhere(['like', 'route', $this->route])
+            ->andFilterWhere(['like', 'name', $this->name])
+            ->andFilterWhere(['like', 'description', $this->description]);
 
         return $dataProvider;
     }

--- a/src/views/cron-task/_form.php
+++ b/src/views/cron-task/_form.php
@@ -11,6 +11,10 @@ use yii\widgets\ActiveForm;
 <div class="cron-task-form">
 
     <?php $form = ActiveForm::begin(); ?>
+    
+    <?= $form->field($model, 'name')->textInput(['maxLength' => true, 'placeholder' => 'Task name']) ?>
+    
+    <?= $form->field($model, 'description')->textInput(['placeholder' => 'Task description']) ?>
 
     <?= $form->field($model, 'schedule')->textInput(['maxlength' => true, 'placeholder' => 'Crontab schedule expression']) ?>
 

--- a/src/views/cron-task/_search.php
+++ b/src/views/cron-task/_search.php
@@ -16,6 +16,10 @@ use yii\widgets\ActiveForm;
     ]); ?>
 
     <?= $form->field($model, 'id') ?>
+    
+    <?= $form->field($model, 'name') ?>
+    
+    <?= $form->field($model, 'description') ?>
 
     <?= $form->field($model, 'created_at') ?>
 

--- a/src/views/cron-task/index.php
+++ b/src/views/cron-task/index.php
@@ -29,7 +29,11 @@ $this->params['breadcrumbs'][] = $this->title;
             'columns' => [
                 [
                     'attribute' => 'id',
-                    'headerOptions' => ['style' => 'width:8%'],
+                    'headerOptions' => ['style' => 'width:5%'],
+                ],
+                [
+                    'attribute' => 'name',
+                    'headerOptions' => ['style' => 'width:14%']
                 ],
                 [
                     'attribute' => 'updated_at',

--- a/src/views/cron-task/update.php
+++ b/src/views/cron-task/update.php
@@ -5,7 +5,9 @@ use yii\helpers\Html;
 /* @var $this yii\web\View */
 /* @var $model gaxz\crontab\models\CronTask */
 
-$this->title = "Update ID:{$model->id} ({$model->route})";;
+$this->title = (!empty($model->name) ? 
+      "Update ID: {$model->id} - {$model->name}" 
+    : "Update ID: {$model->id} ({$model->route})");
 $this->params['breadcrumbs'][] = ['label' => 'Cron Tasks', 'url' => ['index']];
 $this->params['breadcrumbs'][] = ['label' => $model->id, 'url' => ['view', 'id' => $model->id]];
 $this->params['breadcrumbs'][] = 'Update';
@@ -13,6 +15,9 @@ $this->params['breadcrumbs'][] = 'Update';
 <div class="cron-task-update">
 
     <h1><?= Html::encode($this->title) ?></h1>
+    <?php if (!empty($model->name)) { ?>
+        <h4><?= Html::encode($model->route) ?></h4>
+    <?php } ?>
 
     <?= $this->render('_form', [
         'model' => $model,

--- a/src/views/cron-task/update.php
+++ b/src/views/cron-task/update.php
@@ -5,9 +5,8 @@ use yii\helpers\Html;
 /* @var $this yii\web\View */
 /* @var $model gaxz\crontab\models\CronTask */
 
-$this->title = (!empty($model->name) ? 
-      "Update ID: {$model->id} - {$model->name}" 
-    : "Update ID: {$model->id} ({$model->route})");
+$this->title = "Update {$model->getPrettyName()}";
+
 $this->params['breadcrumbs'][] = ['label' => 'Cron Tasks', 'url' => ['index']];
 $this->params['breadcrumbs'][] = ['label' => $model->id, 'url' => ['view', 'id' => $model->id]];
 $this->params['breadcrumbs'][] = 'Update';
@@ -15,9 +14,6 @@ $this->params['breadcrumbs'][] = 'Update';
 <div class="cron-task-update">
 
     <h1><?= Html::encode($this->title) ?></h1>
-    <?php if (!empty($model->name)) { ?>
-        <h4><?= Html::encode($model->route) ?></h4>
-    <?php } ?>
 
     <?= $this->render('_form', [
         'model' => $model,

--- a/src/views/cron-task/view.php
+++ b/src/views/cron-task/view.php
@@ -9,14 +9,21 @@ use yii\widgets\DetailView;
 /* @var $this yii\web\View */
 /* @var $model gaxz\crontab\models\CronTask */
 
-$this->title = "ID:{$model->id} ({$model->route})";
+$this->title = (!empty($model->name) ? 
+      "ID: {$model->id} - {$model->name}" 
+    : "ID: {$model->id} ({$model->route})");
+    
 $this->params['breadcrumbs'][] = ['label' => 'Cron Tasks', 'url' => ['index']];
 $this->params['breadcrumbs'][] = $this->title;
 ?>
 <div class="cron-task-view">
 
     <h1><?= Html::encode($this->title) ?></h1>
-
+    
+    <?php if (!empty($model->name)) { ?>
+        <h4><?= Html::encode($model->route) ?></h4>
+    <?php } ?>
+        
     <p>
 
         <?= Html::a('Execute', ['execute', 'id' => $model->id], ['class' => 'btn btn-primary']) ?>
@@ -35,6 +42,8 @@ $this->params['breadcrumbs'][] = $this->title;
         'model' => $model,
         'attributes' => [
             'id',
+            'name',
+            'description',
             'created_at',
             'updated_at',
             'schedule',

--- a/src/views/cron-task/view.php
+++ b/src/views/cron-task/view.php
@@ -9,9 +9,7 @@ use yii\widgets\DetailView;
 /* @var $this yii\web\View */
 /* @var $model gaxz\crontab\models\CronTask */
 
-$this->title = (!empty($model->name) ? 
-      "ID: {$model->id} - {$model->name}" 
-    : "ID: {$model->id} ({$model->route})");
+$this->title = $model->getPrettyName();
     
 $this->params['breadcrumbs'][] = ['label' => 'Cron Tasks', 'url' => ['index']];
 $this->params['breadcrumbs'][] = $this->title;
@@ -19,10 +17,6 @@ $this->params['breadcrumbs'][] = $this->title;
 <div class="cron-task-view">
 
     <h1><?= Html::encode($this->title) ?></h1>
-    
-    <?php if (!empty($model->name)) { ?>
-        <h4><?= Html::encode($model->route) ?></h4>
-    <?php } ?>
         
     <p>
 


### PR DESCRIPTION
Simply adding name and description (both optional) to CronTask model.
If task name is present, view titles will acommodate consequently.